### PR TITLE
Normalize iss/issuer comparisons consistently across all three sites

### DIFF
--- a/solid-oidc.js
+++ b/solid-oidc.js
@@ -38,6 +38,16 @@ function base64urlDecode(str) {
 }
 
 // ============================================================================
+// URL Helpers
+// ============================================================================
+
+// Normalize URLs by trimming a single trailing slash, so iss/issuer
+// comparisons survive trailing-slash variance between OIDC discovery doc,
+// redirect `iss` parameter, and token `iss` claim. RFC 9207 §2.3 requires
+// comparison after normalization.
+const trimSlash = (s) => (typeof s === 'string' && s.endsWith('/')) ? s.slice(0, -1) : s
+
+// ============================================================================
 // Web Crypto JWT Helpers (replaces jose dependency)
 // ============================================================================
 
@@ -90,7 +100,7 @@ async function verifyJWT(token, jwksUri, options = {}) {
   const header = JSON.parse(new TextDecoder().decode(base64urlDecode(parts[0])))
   const payload = JSON.parse(new TextDecoder().decode(base64urlDecode(parts[1])))
 
-  if (options.issuer && payload.iss !== options.issuer) {
+  if (options.issuer && trimSlash(payload.iss) !== trimSlash(options.issuer)) {
     throw new Error(`Issuer mismatch: ${payload.iss} !== ${options.issuer}`)
   }
   if (options.audience) {
@@ -453,7 +463,6 @@ export class Session extends EventTarget {
 
     // RFC 9207: Verify issuer
     const issuer = config.issuer
-    const trimSlash = (s) => s.endsWith('/') ? s.slice(0, -1) : s
     if (trimSlash(idp) !== trimSlash(issuer)) {
       throw new Error(`Issuer mismatch: ${issuer} !== ${idp}`)
     }
@@ -507,7 +516,7 @@ export class Session extends EventTarget {
     // RFC 9207: Verify issuer
     const idp = sessionStorage.getItem('solid_oidc_idp')
     const iss = url.searchParams.get('iss')
-    if (!idp || iss !== idp) {
+    if (!idp || trimSlash(iss) !== trimSlash(idp)) {
       throw new Error(`Issuer mismatch: ${iss} !== ${idp}`)
     }
 


### PR DESCRIPTION
Closes #7.

`solid-oidc.js` had three `iss` / `issuer` comparison sites but only the discovery-time check normalized trailing slashes. This PR lifts `trimSlash` to module scope and applies it consistently at all three sites.

## Changes

- **New module-level `trimSlash` helper** (with brief JSDoc-style comment) placed after the base64url helpers
- **Site 1 (line ~466, discovery-time)**: removed local duplicate `trimSlash` definition; uses module-level one
- **Site 2 (line ~519, redirect-callback)**: now uses `trimSlash(iss) !== trimSlash(idp)` instead of strict `iss !== idp`
- **Site 3 (line ~103, token validation)**: now uses `trimSlash(payload.iss) !== trimSlash(options.issuer)` instead of strict comparison

Diff: 12 insertions, 3 deletions in one file.

## Reference

RFC 9207 §2.3 requires comparison after normalization. Failure mode prior to this PR was fail-closed (legitimate logins rejected) when an IdP served slightly different URL forms between the discovery doc, the redirect `iss` parameter, and the token `iss` claim — a common pattern across implementations.