### PR TITLE
Bind Session.authFetch so it's safe to pass by reference

### DIFF
--- a/solid-oidc.js
+++ b/solid-oidc.js
@@ -421,6 +421,11 @@ export class Session extends EventTarget {
     this._idpDetails = null
     this._refreshPromise = null
 
+    // Bind so authFetch survives being passed by reference (drop-in fetch):
+    // consumers hand it to rdflib / solid-logic / rdf-dereference as a bare
+    // `fetch`, which would otherwise lose `this`.
+    this.authFetch = this.authFetch.bind(this)
+
     // Set up event listeners
     if (this.onStateChange) {
       this.addEventListener(SessionEvents.STATE_CHANGE, this.onStateChange)

--- a/test.html
+++ b/test.html
@@ -256,6 +256,23 @@
       }
     })
 
+    asyncTest('Session: authFetch survives being passed by reference (bound)', async () => {
+      const session = new Session()
+      // Bare reference, the way rdflib / solid-logic / rdf-dereference take it.
+      // Before binding this throws "Cannot read properties of undefined (reading '_isActive')".
+      const { authFetch } = session
+      const origFetch = globalThis.fetch
+      globalThis.fetch = async () => new Response(null, { status: 200 })
+      try {
+        await authFetch('https://example.com', { method: 'HEAD' })
+        assert(true, 'authFetch is callable when passed by reference')
+      } catch (e) {
+        assert(false, `authFetch lost its binding when passed by reference: ${e.message}`)
+      } finally {
+        globalThis.fetch = origFetch
+      }
+    })
+
     // ==========================================================================
     // Summary
     // ==========================================================================


### PR DESCRIPTION
Fixes #11.

`Session.authFetch` is the authenticated drop-in for `fetch`, but it was an ordinary unbound class method, so passing it by reference lost `this`:

```js
const f = session.authFetch
await f(url)   // TypeError: cannot read properties of undefined (reading '_isActive')
```

That breaks any consumer handing the authed fetch to a library expecting a bare `fetch` (rdflib `Fetcher` / `UpdateManager`, rdf-dereference, solid-logic) or destructuring it.

## Change

One line in the `Session` constructor:

```js
this.authFetch = this.authFetch.bind(this)
```

Plus a test in `test.html` that destructures `authFetch` and calls it with a mocked `fetch`, which throws pre-bind and passes post-bind.

## Notes

Not a live regression for current consumers (they call `session.authFetch(...)` directly or go through a wrapper); this is hardening so the public API meets its drop-in-`fetch` contract.